### PR TITLE
[CI] Add a GitHub Actions workflow for CI to build PR'd code

### DIFF
--- a/.github/workflows/on_pull_request_ci.yml
+++ b/.github/workflows/on_pull_request_ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  pull_request_target:
+
+jobs:
+  build:
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
+      - name: configure brew running environment
+        run: |
+          brew brew update-reset
+          brew tap nnstreamer/neural-network
+          brew update
+      - name: build formula from source
+        run: |
+          brew install --build-from-source ./Formula/nnstreamer.rb -v


### PR DESCRIPTION
This patch sets up a CI pipeline for PR'd code using the GitHub Actions workflow. Note that this pipeline will replace the existing Travis-CI pipeline soon.

Signed-off-by: Wook Song <wook16.song@samsung.com>