### PR TITLE
Configure CI system based on GitHub Actions

### DIFF
--- a/.github/workflows/ci_on_pr_and_push.yml
+++ b/.github/workflows/ci_on_pr_and_push.yml
@@ -10,7 +10,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-10.15, macos-11]
     steps:
       - uses: actions/checkout@v2
       - name: configure brew running environment

--- a/.github/workflows/ci_on_pr_and_push.yml
+++ b/.github/workflows/ci_on_pr_and_push.yml
@@ -1,14 +1,18 @@
 name: CI
 on:
-  pull_request_target:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - master
 
 jobs:
   build:
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
       - name: configure brew running environment
         run: |
           brew update-reset


### PR DESCRIPTION
This PR is about to migrate the CI system for this repository from Travis-CI to GitHub Actions.
After making nnstreamer.rb (2,0) buildable, force-merging might be required.

Signed-off-by: Wook Song <wook16.song@samsung.com>