### PR TITLE
[Formula/NNStreamer] Bump up to v2.0.0

### DIFF
--- a/Formula/nnstreamer.rb
+++ b/Formula/nnstreamer.rb
@@ -1,29 +1,43 @@
 class Nnstreamer < Formula
   desc "Neural Network (NN) Streamer, Stream Processing Paradigm for Neural Network Apps/Devices."
-  homepage "https://github.com/nnsuite/nnstreamer"
-  url "https://github.com/nnsuite/nnstreamer/archive/c110844c31bd0fb4eb0a8cf6ac8bf969c81db397.tar.gz"
-  version "1.0.0"
-  sha256 "d4397a77a18fc0d881b2aff4fdf68e251ccea7ca84d8a765c52eee0df1cd7e76"
-  depends_on :macos
-  depends_on "meson" => :build
-  depends_on "ninja" => :build
-  depends_on "pkg-config" => :build
-  depends_on "cmake" => :build
-  depends_on "googletest" => :build
-  depends_on "ssat" => :build
-  depends_on "protobuf"
-  depends_on "libffi"
-  depends_on "glib"
-  depends_on "gstreamer"
-  depends_on "gst-plugins-base"
-  depends_on "gst-plugins-good"
-  depends_on "numpy"
+  homepage "https://github.com/nnstreamer/nnstreamer"
+  stable do
+    url "https://github.com/nnstreamer/nnstreamer/archive/refs/tags/v2.0.0.tar.gz"
+    version "2.0.0"
+    sha256 "1282297ec55d1b87781c218b8ac313b24ae9636c6b41519a5c8435f71b07395a"
+    patch do
+      url "https://raw.githubusercontent.com/nnstreamer/homebrew-neural-network/master/Formula/nnstreamer-patches/0001-Local-Tests-Skip-the-SSAT-based-test-cases-that-fail.patch"
+      sha256 "648e409ceec36247e5ba614d9feb0a807675d68441c8b194e9bfa98b636c539f"
+    end
+    patch do
+      url "https://raw.githubusercontent.com/nnstreamer/homebrew-neural-network/master/Formula/nnstreamer-patches/0002-Local-Query-Common-Replace-EREMOTEIO-with-ENOTCONN.patch"
+      sha256 "ff58094a81c98db97b4da9fe43b7180eae24e68e0512252d3105a3720c6d258c"
+    end
+    patch do
+      url "https://raw.githubusercontent.com/nnstreamer/homebrew-neural-network/master/Formula/nnstreamer-patches/0003-Local-Tests-FilterExtCommon-Add-a-missing-parameter-.patch"
+      sha256 "f2f5c0b5ad3a31889f945f19b1b484c863ad14295d5d5e67c6e188f87b8f24f7"
+    end
+    depends_on :macos
+    depends_on "meson" => :build
+    depends_on "ninja" => :build
+    depends_on "pkg-config" => :build
+    depends_on "cmake" => :build
+    depends_on "googletest" => :build
+    depends_on "ssat" => :build
+    depends_on "bison"
+    depends_on "flex"
+    depends_on "protobuf"
+    depends_on "libffi"
+    depends_on "glib"
+    depends_on "gstreamer"
+    depends_on "gst-plugins-base"
+    depends_on "gst-plugins-good"
+    depends_on "numpy"
+  end
 
   def install
     system "rm", "-rf", "build"
-    system "meson", "build", "--prefix=#{prefix}", "--sysconfdir=#{prefix}/etc",\
-        "-Denable-tensorflow-lite=false", "-Denable-pytorch=false", \
-        "-Denable-caffe2=false", "-Denable-tensorflow=false"
+    system "meson", "build", "--prefix=#{prefix}", "--sysconfdir=#{prefix}/etc"
     system "ninja", "-C", "build"
     # Before installation, run build-time tests
     cd "build" do
@@ -36,10 +50,8 @@ class Nnstreamer < Formula
       system "./tests/unittest_plugins"
     end
     cd "tests" do
-      system "mv", "nnstreamer_repo_dynamicity/runTest.sh", "nnstreamer_repo_dynamicity/runTest.sh.bak"
       # FIXME: Several tests are going to be failed
       system "ssat", "--progress"
-      system "mv", "nnstreamer_repo_dynamicity/runTest.sh.bak", "nnstreamer_repo_dynamicity/runTest.sh"
     end
     cd "build" do
       system "ninja", "install"


### PR DESCRIPTION
This patch bumps up NNStreamer to v2.0.0 (Long-Term-Stable release of 2022).

Signed-off-by: Wook Song <wook16.song@samsung.com>